### PR TITLE
#325 add preload of fonts before CSS rendering

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/wknd/components/page/customheaderlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/wknd/components/page/customheaderlibs.html
@@ -15,6 +15,11 @@
 */-->
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
+<!--/* Preload fonts to speed up LCP */-->
+<link rel="preload" href="https://fonts.gstatic.com/s/sourcesanspro/v13/6xK3dSBYKcSV-LCoeQqfX1RYOo3qOK7lujVj9w.woff2" as="font" type="font/woff2" crossorigin> 
+<link rel="preload" href="https://fonts.gstatic.com/s/asar/v7/sZlLdRyI6TBIbkEaDZtQS6A.woff2" as="font" type="font/woff2" crossorigin> 
+<link rel="preload" href="https://fonts.gstatic.com/s/sourcesanspro/v13/6xKydSBYKcSV-LCoeQqfX1RYOo3i54rwlxdu3cOWxw.woff2" as="font" type="font/woff2" crossorigin> 
+
 <!--/* Include Context Hub 
 <sly data-sly-resource="${'contexthub' @ resourceType='granite/contexthub/components/contexthub'}"/>
 */-->


### PR DESCRIPTION
The fonts are currently only referenced in the CSS - the browser only starts downloading the fonts when it gets to render the CSS - that is late- and slows down overall paint of LCP. Preloading them earlier allows the browser to start painting earlier.